### PR TITLE
Fix incorrect source path in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "trading-ideas",
-      "source": "./trading-ideas.md",
+      "source": "./commands/trading-ideas.md",
       "description": "Institutional-grade equity research reports via /trading-ideas command. Analyzes company financials, technical indicators, market positioning, insider activity, and provides BUY/SELL/HOLD recommendations with price targets.",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
## Summary
- Fixed the plugin source path in `.claude-plugin/marketplace.json`
- Changed `./trading-ideas.md` to `./commands/trading-ideas.md` to match actual file location

## Problem
Plugin installation fails with error:
```
Error: Failed to install: Source path does not exist: .../trading-ideas.md
```

## Test plan
- [ ] Run `/plugin marketplace add quant-sentiment-ai/claude-equity-research` after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)